### PR TITLE
Fix Access denied for media source

### DIFF
--- a/assets/components/mixedimage/js/mgr/mixedimage.js
+++ b/assets/components/mixedimage/js/mgr/mixedimage.js
@@ -206,6 +206,7 @@ Ext.extend(mixedimage.fileform,Ext.FormPanel,{
             ,lex: config.TV.jsonlex
             ,ctx_path: config.TV.ctx_path 
             //,resize: config.resize
+            ,source: config.TV.ms_id
         };
     }
     ,getItems:function(config){


### PR DESCRIPTION
In MODx 2.8.0 changelog: 
Prevent limited manager users from interacting with files in any media source.
On upload file didn't send 'source' param (id media source) and new modx restricted access to media source id=1 (Filesystem) by default.